### PR TITLE
fix: Avoid CORS errors when training image models with hosted images

### DIFF
--- a/src/com/kylecorry/ml4k/assets/ml4k.js
+++ b/src/com/kylecorry/ml4k/assets/ml4k.js
@@ -280,7 +280,7 @@ function _ml4kGetImageData(imageid, imageurl, imagelabel) {
 function _ml4kGetTrainingImages(scratchkey) {
     console.log('getting training images');
     var labels = new Set();
-    return _ml4kFetchJson('https://machinelearningforkids.co.uk/api/scratch/' + scratchkey + '/train')
+    return _ml4kFetchJson('https://machinelearningforkids.co.uk/api/scratch/' + scratchkey + '/train?proxy=true')
         .then(function (imagesList) {
             return pool({
                 collection: imagesList,


### PR DESCRIPTION
Some web servers are rejecting requests from App Inventor to download
training images, because they are configured to reject cross-origin
requests.

To avoid this, the App Inventor extension needs to download images
via the ML for Kids server as a proxy.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>