### PR TITLE
chore: remove dead code for the now-removed "images" project type

### DIFF
--- a/downloadtfjs.sh
+++ b/downloadtfjs.sh
@@ -7,7 +7,7 @@ if [ ! -f "../src/com/kylecorry/ml4k/assets/model.json" ]; then
     do
         curl https://storage.googleapis.com/tfjs-models/tfjs/mobilenet_v1_0.25_224/group$i-shard1of1 -o ../src/com/kylecorry/ml4k/assets/group$i-shard1of1
     done
-    npm install @tensorflow/tfjs
+    npm install @tensorflow/tfjs@3.12.0
     cp node_modules/@tensorflow/tfjs/dist/tf.min.js ../src/com/kylecorry/ml4k/assets/.
     npm install @ricokahler/pool
     cp node_modules/@ricokahler/pool/dist/index.js ../src/com/kylecorry/ml4k/assets/promisepool.js

--- a/downloadtfjs.sh
+++ b/downloadtfjs.sh
@@ -7,7 +7,7 @@ if [ ! -f "../src/com/kylecorry/ml4k/assets/model.json" ]; then
     do
         curl https://storage.googleapis.com/tfjs-models/tfjs/mobilenet_v1_0.25_224/group$i-shard1of1 -o ../src/com/kylecorry/ml4k/assets/group$i-shard1of1
     done
-    npm install @tensorflow/tfjs@3.12.0
+    npm install @tensorflow/tfjs@3.14.0
     cp node_modules/@tensorflow/tfjs/dist/tf.min.js ../src/com/kylecorry/ml4k/assets/.
     npm install @ricokahler/pool
     cp node_modules/@ricokahler/pool/dist/index.js ../src/com/kylecorry/ml4k/assets/promisepool.js

--- a/src/com/kylecorry/ml4k/ML4KComponent.java
+++ b/src/com/kylecorry/ml4k/ML4KComponent.java
@@ -198,10 +198,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
                             data = ((ClassifyTextAction)classifyAction).text;
                             classification = ml4k.classify(data);
                             break;
-                        case ClassifyImage:
-                            data = ((ClassifyImageAction)classifyAction).imagePath;
-                            classification = ml4k.classify(loadImageFile(data));
-                            break;
                         case ClassifyNumbers:
                             YailList numbers = ((ClassifyNumbersAction)classifyAction).numbers;
                             data = numbers.toString();
@@ -677,7 +673,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
                     case "text":
                         addTrainingDataToProject(action);
                         break;
-                    case "images":
                     case "imgtfjs":
                         displayErrorMessage(EXPLAIN_API_KEY_TYPE_IMAGES);
                         break;
@@ -691,7 +686,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
                 break;
             case AddImageTraining:
                 switch (projectType) {
-                    case "images":
                     case "imgtfjs":
                         addTrainingDataToProject(action);
                         break;
@@ -711,7 +705,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
                     case "numbers":
                         addTrainingDataToProject(action);
                         break;
-                    case "images":
                     case "imgtfjs":
                         displayErrorMessage(EXPLAIN_API_KEY_TYPE_IMAGES);
                         break;
@@ -729,7 +722,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
                     case "text":
                         classifyTestDataOnServer(action);
                         break;
-                    case "images":
                     case "imgtfjs":
                         displayErrorMessage(EXPLAIN_API_KEY_TYPE_IMAGES);
                         break;
@@ -743,9 +735,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
                 break;
             case ClassifyImage:
                 switch (projectType) {
-                    case "images":
-                        classifyTestDataOnServer(action);
-                        break;
                     case "imgtfjs":
                         classifyImageWithTensorflow(((ClassifyImageAction)action).imagePath);
                         break;
@@ -765,7 +754,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
                     case "numbers":
                         classifyTestDataOnServer(action);
                         break;
-                    case "images":
                     case "imgtfjs":
                         displayErrorMessage(EXPLAIN_API_KEY_TYPE_IMAGES);
                         break;
@@ -780,7 +768,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
             // ML model actions
             case TrainModel:
                 switch (projectType) {
-                    case "images":
                     case "text":
                     case "numbers":
                         trainModelWithWatson();
@@ -795,7 +782,6 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
                 break;
             case CheckModelStatus:
                 switch (projectType) {
-                    case "images":
                     case "text":
                     case "numbers":
                         fetchModelStatusFromServer();

--- a/src/com/kylecorry/ml4k/ML4KComponent.java
+++ b/src/com/kylecorry/ml4k/ML4KComponent.java
@@ -76,7 +76,7 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
 
 
 
-    public ML4KComponent(ComponentContainer container) {
+    public ML4KComponent(ComponentContainer container) {
         super(container.$form());
         activity = container.$context();
 

--- a/src/com/kylecorry/ml4k/ML4KComponent.java
+++ b/src/com/kylecorry/ml4k/ML4KComponent.java
@@ -72,7 +72,9 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
     private final static String EXPLAIN_API_KEY_TYPE_NUMBERS = "You created a machine learning project to recognise numbers, so you can only use the numbers ML blocks in this project.";
     private final static String EXPLAIN_API_KEY_TYPE_IMAGES = "You created a machine learning project to recognise images, so you can only use the images ML blocks in this project.";
     private final static String EXPLAIN_API_KEY_TYPE_SOUNDS = "You created a machine learning project to recognise sounds, so you cannot use that block";
-    private final static String EXPLAIN_ML_MODEL_NEEDED = "Please train a machine learning model before you try to do this.";
+    private final static String EXPLAIN_ML_MODEL_NEEDED = "Please train a machine learning model before you try to do this. You must do this in your App Inventor project, using the 'TrainNewModel' block.";
+    private final static String EXPLAIN_ML_MODEL_NOTREADY = "Your machine learning model is still training. Please wait for this to complete.";
+    private final static String EXPLAIN_ML_MODEL_FAILED = "Sorry! Your machine learning model failed to train.";
 
 
 
@@ -478,9 +480,19 @@ public final class ML4KComponent extends AndroidNonvisibleComponent {
     private void classifyImageWithTensorflow(final String path) {
         initialiseTensorFlow();
 
-        if (!webPageObj.getModelStatus().equals("Available")) {
-            displayErrorMessage(EXPLAIN_ML_MODEL_NEEDED);
-            return;
+        switch (webPageObj.getModelStatus()) {
+            case "Not trained":
+                displayErrorMessage(EXPLAIN_ML_MODEL_NEEDED);
+                return;
+            case "Failed":
+                displayErrorMessage(EXPLAIN_ML_MODEL_FAILED);
+                return;
+            case "Training":
+                displayErrorMessage(EXPLAIN_ML_MODEL_NOTREADY);
+                return;
+            case "Available":
+                // yay, we're all good!
+                break;
         }
 
         runInBackground(new Runnable() {

--- a/src/com/kylecorry/ml4k/ModelStatus.java
+++ b/src/com/kylecorry/ml4k/ModelStatus.java
@@ -29,7 +29,16 @@ class ModelStatus {
         if (message == null || type == null){
             throw new ML4KException("JSON is not valid: " + json);
         }
-        return new ModelStatus(code, message, type);
+        if (type.equals("text") ||
+            type.equals("imgtfjs") ||
+            type.equals("numbers") ||
+            type.equals("sounds"))
+        {
+            return new ModelStatus(code, message, type);
+        }
+        else {
+            throw new ML4KException("Unexpected project type: " + type);
+        }
     }
 
     /**


### PR DESCRIPTION
The "images" project type used the IBM Visual Recognition service
which is no longer available. This commit is a tiny bit of tidying
up to remove the code that handled that type. (It's not super
essential, as at the moment that code is just never called).

I've also updated the version of TensorFlow used in the extension
as there are a bunch of fixes and performance improvements that
went into the version since we last built this.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>